### PR TITLE
Correct the SPI error behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ These three registers simulate the SPI handshaing behavior as used e.g. in [Moto
 Register name | Address | Description
 ------------- | --------|-----
 WORD_SPI_WRITE | 0x00000050 | Write data if SPI_SYNC was set to SYNC_REQUESTED (0xFF). 
-WORD_SPI_READ | 0x00000054 | Set to SYNC_ERROR (0xAA) if SPI_SYNC was not set to SYNC_REQUESTED or if the driver is configured to fail SPI. Otherwise will contain what was written to WORD_SPI_WRITE
-WORD_SPI_SYNC | 0x00000058 | Ret to SYNC_REQUESTED (0xFF) before writing to WORD_SPI_WRITE for a successful write.
+WORD_SPI_READ | 0x00000054 | Will contain what was written to WORD_SPI_WRITE if WORD_SPI_SYNC was set to SYNC_REQUESTED and SPI was not configured to fail before the write, untouched otherwise
+WORD_SPI_SYNC | 0x00000058 | Set to SYNC_REQUESTED (0xFF) before writing to WORD_SPI_WRITE for a successful write. Will be reset to 0 after successful write, to SYNC_ERROR (0xAA) otherwise.
 
 ## Querying the current state
 ```

--- a/mtcadummy_firmware.c
+++ b/mtcadummy_firmware.c
@@ -99,11 +99,11 @@ int mtcadummy_performActionOnWrite(u32 offset, unsigned int barNumber, unsigned 
     case MTCADUMMY_BROKEN_WRITE:
       return -1;
     case MTCADUMMY_WORD_SPI_WRITE:
-      if (REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_SYNC) == MTCADUMMY_SPI_SYNC_REQUESTED) {
+      if (REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_SYNC) == MTCADUMMY_SPI_SYNC_REQUESTED && !spiFail) {
         REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_READ) = REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_WRITE);
-        REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_SYNC) = spiFail ? MTCADUMMY_SPI_SYNC_ERROR : MTCADUMMY_SPI_SYNC_OK;
+        REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_SYNC) = MTCADUMMY_SPI_SYNC_OK;
       } else {
-        REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_READ) = MTCADUMMY_SPI_SYNC_ERROR;
+        REG(systemBarBaseAddress, MTCADUMMY_WORD_SPI_SYNC) = MTCADUMMY_SPI_SYNC_ERROR;
       }
       break;
     default:


### PR DESCRIPTION
It was setting the status in the _READ register if the _SYNC register was not set to SYNC_REQUEST before write.