### PR TITLE
fix: Allow overriding KEREL_SRC

### DIFF
--- a/Makefile.kernel
+++ b/Makefile.kernel
@@ -2,11 +2,12 @@ mtcadummy-objs := mtcadummy_drv.o mtcadummy_proc.o mtcadummy_firmware.o mtcadumm
 obj-m += mtcadummy.o
 
 KVERSION = $(shell uname -r)
+KERNEL_SRC = /lib/modules/$(KVERSION)/build
 
 ccflags-y = -Wall -Wuninitialized
 
 all:
-	make -C /lib/modules/$(KVERSION)/build V=1 M=$(PWD) modules
+	$(MAKE) -C $(KERNEL_SRC) V=1 M=$(PWD) modules
 
 #Compile with debug flag, causes lots of kernel output, which fills the logs
 #and slows down the driver.
@@ -19,7 +20,7 @@ full_debug:
 	KCPPFLAGS="-DPCIEUNI_DEBUG -fprofile-arcs -ftest-coverage" make all
 
 clean:
-	make -C /lib/modules/$(KVERSION)/build V=1 M=$(PWD) clean
+	$(MAKE) -C $(KERNEL_SRC) V=1 M=$(PWD) clean
 
 #the two possible locations where the gpcieuni include files can be
 #/usr/local in case of a local, manual installation by the admin

--- a/Makefile.kernel
+++ b/Makefile.kernel
@@ -22,8 +22,4 @@ full_debug:
 clean:
 	$(MAKE) -C $(KERNEL_SRC) V=1 M=$(PWD) clean
 
-#the two possible locations where the gpcieuni include files can be
-#/usr/local in case of a local, manual installation by the admin
-#/usr in case of an installation by the package management
-EXTRA_CFLAGS += -I/usr/include
 


### PR DESCRIPTION
Got lost by the move to new CMake scheme, necessary for Yocto
